### PR TITLE
Potential fix for code scanning alert no. 2: Flask app is run in debug mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -126,5 +126,5 @@ def getMetrics():
 
 if __name__ == '__main__':
     # only runs when run locally
-    app.run(debug=True)
+    app.run(debug=os.environ.get("FLASK_DEBUG", "0") == "1")
 


### PR DESCRIPTION
Potential fix for [https://github.com/Johang727/TECSRCalc/security/code-scanning/2](https://github.com/Johang727/TECSRCalc/security/code-scanning/2)

To address this security issue, the Flask server should not be run with `debug=True` unconditionally. The best practice is to determine the debug setting based on an environment variable (e.g., `FLASK_DEBUG`) or, for stricter security, to always set `debug=False` in the `app.run()` for safety, and let Flask's own CLI be used for debugging during development. One simple fix is to remove `debug=True` entirely (the default is `False`). Alternatively, use `debug=os.environ.get("FLASK_DEBUG", "0") == "1"` to only enable debug mode when explicitly set in the environment. The necessary import for `os` is already present, so no new imports are needed.

Edit `app.py`:
- Replace `app.run(debug=True)` with a version that sets debug mode only if an environment variable is set, or simply remove the `debug=True` argument entirely.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
